### PR TITLE
Fix link for ImEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ImCompressor is a lossless image compressor.
 It is inspired by [Trimage](https://github.com/Kilian/Trimage) and [Image-Optimizer](https://github.com/GijsGoudzwaard/Image-Optimizer).
 
-By the same developer as [ImEditor](https://github.com/ImEditor/ImEditor)
+By the same developer as [ImEditor](https://github.com/ImEditor/ImEditor).
 
 ### Supported formats
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ImCompressor is a lossless image compressor.
 It is inspired by [Trimage](https://github.com/Kilian/Trimage) and [Image-Optimizer](https://github.com/GijsGoudzwaard/Image-Optimizer).
 
-By the same developer as [ImEditor](paypal.me/hposnic).
+By the same developer as [ImEditor](https://github.com/ImEditor/ImEditor)
 
 ### Supported formats
 


### PR DESCRIPTION
The original link was going to the wrong place and was also formatted incorrectly, leading to it linking to a non-existent location in this repo.