### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.github.huluti.Curtail.desktop.in
+++ b/data/com.github.huluti.Curtail.desktop.in
@@ -10,5 +10,6 @@ Icon=com.github.huluti.Curtail
 StartupWMClass=curtail
 MimeType=image/jpeg;image/png;
 StartupNotify=true
+DBusActivatable=true
 # Keywords, do not translate
 Keywords=compress;optimize;image;photo;

--- a/data/com.github.huluti.Curtail.service.in
+++ b/data/com.github.huluti.Curtail.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/curtail --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,4 @@
+bindir = join_paths(get_option('prefix'), get_option('bindir'))
 pkgdatadir = join_paths(get_option('prefix'), get_option('datadir'), meson.project_name())
 
 gnome = import('gnome')
@@ -51,5 +52,15 @@ if compile_schemas.found()
     args: ['--strict', '--dry-run', meson.current_source_dir()]
   )
 endif
+
+service_conf = configuration_data()
+service_conf.set('app-id', application_id)
+service_conf.set('bindir', bindir)
+configure_file(
+  input: 'com.github.huluti.Curtail.service.in',
+  output: 'com.github.huluti.Curtail.service',
+  configuration: service_conf,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1', 'services')
+)
 
 subdir('icons')


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html