### PR TITLE
Use GFile instead of pathlib

### DIFF
--- a/src/compressor.py
+++ b/src/compressor.py
@@ -18,11 +18,9 @@
 import threading
 import subprocess
 import logging
-import shutil
 import os
 from concurrent.futures import ThreadPoolExecutor
 from gi.repository import GLib, Gio
-from pathlib import Path
 from shlex import quote
 
 from .tools import get_file_type
@@ -70,7 +68,10 @@ class Compressor:
         )
         result_item.filename = tmp_filename
         result_item.new_filename = tmp_filename
-        shutil.copy2(result_item.original_filename, result_item.filename)
+
+        source = Gio.File.new_for_path(result_item.original_filename)
+        dest = Gio.File.new_for_path(result_item.filename)
+        source.copy(dest, Gio.FileCopyFlags.COPY_ALL_METADATA)
 
     def compress_images(self):
         threading.Thread(target=self._compress_images, daemon=True).start()
@@ -80,22 +81,25 @@ class Compressor:
         executor = ThreadPoolExecutor(max_workers=cpu_count)
         futures = []
         for result_item in self.result_items:
-            file_type = get_file_type(result_item.filename)
-            if file_type:
-                if file_type == "png":
-                    command = self.build_png_command(result_item)
-                elif file_type == "jpg":
-                    command = self.build_jpg_command(result_item)
-                elif file_type == "webp":  # Must be manually skipped
-                    if not self.do_new_file:
-                        self.create_tmp_result_item(result_item)
-                    command = self.build_webp_command(result_item)
-                elif file_type == "svg":  # Must be manually skipped
-                    if not self.do_new_file:
-                        self.create_tmp_result_item(result_item)
-                    command = self.build_svg_command(result_item)
-                future = executor.submit(self.run_command, command, result_item)
-                futures.append(future)
+            file_type = get_file_type(result_item.file)
+
+            if not file_type:
+                continue
+
+            if file_type == 'png':
+                command = self.build_png_command(result_item)
+            elif file_type == 'jpeg':
+                command = self.build_jpg_command(result_item)
+            elif file_type == 'webp': # Must be manually skipped
+                if not self.do_new_file:
+                    self.create_tmp_result_item(result_item)
+                command = self.build_webp_command(result_item)
+            elif file_type == 'svg': # Must be manually skipped
+                if not self.do_new_file:
+                    self.create_tmp_result_item(result_item)
+                command = self.build_svg_command(result_item)
+            future = executor.submit(self.run_command, command, result_item)
+            futures.append(future)
 
         for future in futures:
             future.result()
@@ -124,25 +128,26 @@ class Compressor:
             error = True
         finally:
             if not error:
-                new_file_data = Path(result_item.new_filename)
-                if new_file_data.is_file():
-                    result_item.new_size = new_file_data.stat().st_size
+                new_file = Gio.File.new_for_path(result_item.new_filename)
+                new_file_info = new_file.query_info("standard::size", Gio.FileQueryInfoFlags.NONE)
+                if new_file.query_exists():
+                    result_item.new_size = new_file_info.get_size()
 
                     # Manually skip files if necessary (WebP or SVG)
-                    if get_file_type(result_item.original_filename) in ["webp", "svg"]:
+                    if get_file_type(result_item.file) in ["webp", "svg"]:
                         if self.do_new_file:
                             if result_item.new_size >= result_item.size:
                                 # Output is larger (or equal) than input in safe mode
                                 # Remove the new file
-                                Path(result_item.new_filename).unlink(True)
+                                new_file.delete()
                                 result_item.skipped = True
                         else:
                             if not result_item.new_size > result_item.size:
                                 # Output is smaller than input in overwrite mode
                                 # Copy the compressed temporary file onto the uncompressed original file
-                                shutil.copy2(
-                                    result_item.filename, result_item.original_filename
-                                )
+                                source = Gio.File.new_for_path(result_item.filename)
+                                dest = Gio.File.new_for_path(result_item.original_filename)
+                                source.copy(dest, Gio.FileCopyFlags.COPY_ALL_METADATA)
                             else:
                                 # Output is smaller than input in overwrite mode
                                 # Set file as skipped, since the temporary file was compressed
@@ -151,18 +156,20 @@ class Compressor:
 
                             # Remove temporary file that was created for overwrite mode
                             # Also set the result_item's information back to the original file
-                            Path(result_item.filename).unlink(True)
+                            result_item.file.delete()
                             result_item.filename = result_item.original_filename
                             result_item.new_filename = result_item.original_filename
-                            new_file_data = Path(result_item.new_filename)
-                            result_item.new_size = new_file_data.stat().st_size
+
+                            new_file = Gio.File.new_for_path(result_item.new_filename)
+                            new_file_info = new_file.query_info("standard::size", Gio.FileQueryInfoFlags.NONE)
+                            result_item.new_size = new_file_info.get_size()
                     elif result_item.size == result_item.new_size:
                         # File was automatically skipped by a compressor
                         result_item.skipped = True
 
                         # Remove new file if in safe mode
                         if self.do_new_file:
-                            Path(result_item.new_filename).unlink(True)
+                            new_file.delete()
                 else:
                     logging.error(str(output))
                     error_message = _("Can't find the compressed file")

--- a/src/resultitem.py
+++ b/src/resultitem.py
@@ -1,11 +1,12 @@
 # resultitem.py
 
-from gi.repository import GObject
+from gi.repository import Gio, GObject
 
 from .tools import sizeof_fmt
 
 
 class ResultItem(GObject.Object):
+    file = GObject.Property(type=Gio.File)
     name = GObject.Property(type=str)
     filename = GObject.Property(type=str)
     new_filename = GObject.Property(type=str)
@@ -19,9 +20,10 @@ class ResultItem(GObject.Object):
     error = GObject.Property(type=bool, default=False)
     error_message = GObject.Property(type=str, default="")
 
-    def __init__(self, name, filename, new_filename, size):
+    def __init__(self, file, name, filename, new_filename, size):
         super().__init__()
 
+        self.file = file
         self.name = name
         self.filename = filename
         self.new_filename = new_filename


### PR DESCRIPTION
This allows us to get the host path from the portal, which is necessary for #185. This code might not be fully optimized (I think we could also use GFile for copying instead of shutil?), but it should work. There's a lot here, so I might've missed something.

Note this doesn't actually close the issue #185 yet. Since users can't choose a different output location, Curtail tries to save the file in the same place, which we don't have permission to do.